### PR TITLE
Add full-text RSS feed

### DIFF
--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -1,0 +1,39 @@
+{{- $pctx := . -}}
+ {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+ {{- $pages := slice -}}
+ {{- if or $.IsHome $.IsSection -}}
+ {{- $pages = $pctx.RegularPages -}}
+ {{- else -}}
+ {{- $pages = $pctx.Pages -}}
+ {{- end -}}
+ {{- $limit := .Site.Config.Services.RSS.Limit -}}
+ {{- if ge $limit 1 -}}
+ {{- $pages = $pages | first $limit -}}
+ {{- end -}}
+ {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+ <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+   <channel>
+     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+     <link>{{ .Permalink }}</link>
+     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+     {{ with .OutputFormats.Get "RSS" }}
+ 	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+     {{ end }}
+     {{ range $pages }}
+     <item>
+       <title>{{ .Title }}</title>
+       <link>{{ .Permalink }}</link>
+       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+       <guid>{{ .Permalink }}</guid>
+       <description>{{ .Content | html }}</description>
+     </item>
+     {{ end }}
+   </channel>
+ </rss>


### PR DESCRIPTION
Hello, I’m a reader of your blog!

I would like to have a full-text RSS feed of your blog if possible (so that I can view the articles in my RSS viewer), but currently the RSS feed only sends a summary of the article.

This PR adds a full-text RSS feed, based on [these](https://www.godo.dev/tutorials/hugo-full-text-rss/) [articles](https://gohugo.io/templates/rss/).

I would also like to add the link to the RSS feed in the `<head>` elements, but I'm not familiar with Hugo, so I'm not sure what to do if there is no `layout/partial/header.html`. 😞